### PR TITLE
clippy warning eliminate

### DIFF
--- a/functional-tests/src/run_config.rs
+++ b/functional-tests/src/run_config.rs
@@ -1,8 +1,6 @@
 // Copyright (c) zkMove Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#![allow(clippy::useless_conversion)]
-
 use anyhow::Result;
 use movelang::argument::ScriptArguments;
 use std::fs::File;
@@ -33,7 +31,7 @@ impl RunConfig {
         let mut buffer = String::new();
         f.read_to_string(&mut buffer)?;
 
-        for line in buffer.lines().into_iter() {
+        for line in buffer.lines() {
             let s = line.split_whitespace().collect::<String>();
             if let Some(s) = s.strip_prefix("//!args:") {
                 config.args = Some(s.parse::<ScriptArguments>()?);

--- a/functional-tests/tests/testsuite.rs
+++ b/functional-tests/tests/testsuite.rs
@@ -1,6 +1,8 @@
 // Copyright (c) zkMove Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#![allow(clippy::redundant_clone)]
+
 use anyhow::Result;
 use halo2_proofs::pasta::{EqAffine, Fp};
 use halo2_proofs::poly::commitment::Params;
@@ -32,7 +34,7 @@ fn parse_config(script_file: &Path) -> Result<RunConfig> {
     let mut buffer = String::new();
     f.read_to_string(&mut buffer)?;
 
-    for line in buffer.lines().into_iter() {
+    for line in buffer.lines() {
         let s = line.split_whitespace().collect::<String>();
         if let Some(s) = s.strip_prefix("//!args:") {
             config.args = Some(s.parse::<ScriptArguments>()?);

--- a/vm/src/chips/chip_tests.rs
+++ b/vm/src/chips/chip_tests.rs
@@ -159,10 +159,7 @@ impl<F: FieldExt> Circuit<F> for TestBranchCircuit<F> {
             self.b,
             self.b_type.clone(),
         )?;
-        let not_cond = match self.cond {
-            Some(v) => Some(F::one() - v),
-            None => None,
-        };
+        let not_cond = self.cond.map(|v| F::one() - v);
         let c = evaluation_chip.binary_op(
             layouter.namespace(|| "a + b"),
             Opcode::Add,
@@ -280,21 +277,21 @@ impl<F: FieldExt> Circuit<F> for RangeCheckTestCircuit<F> {
                 RangeCheckChip::construct(config.range_check_u8).assign(
                     &mut layouter,
                     value.unwrap(),
-                    Some(self.cond.clone()),
+                    Some(self.cond),
                 )?;
             }
             MoveValueType::U64 => {
                 RangeCheckChip::construct(config.range_check_u64).assign(
                     &mut layouter,
                     value.unwrap(),
-                    Some(self.cond.clone()),
+                    Some(self.cond),
                 )?;
             }
             MoveValueType::U128 => {
                 RangeCheckChip::construct(config.range_check_u128).assign(
                     &mut layouter,
                     value.unwrap(),
-                    Some(self.cond.clone()),
+                    Some(self.cond),
                 )?;
             }
             _ => unimplemented!(),

--- a/vm/src/chips/evaluation_chip.rs
+++ b/vm/src/chips/evaluation_chip.rs
@@ -179,43 +179,43 @@ impl<F: FieldExt> EvaluationChip<F> {
         let out = match opcode {
             Opcode::Add => {
                 let add_chip = AddChip::<F>::construct(self.config.add_config.clone(), ());
-                add_chip.assign(&mut layouter, a, b, cond.clone())?
+                add_chip.assign(&mut layouter, a, b, cond)?
             }
             Opcode::Sub => {
                 let sub_chip = SubChip::<F>::construct(self.config.sub_config.clone(), ());
-                sub_chip.assign(&mut layouter, a, b, cond.clone())?
+                sub_chip.assign(&mut layouter, a, b, cond)?
             }
             Opcode::Mul => {
                 let mul_chip = MulChip::<F>::construct(self.config.mul_config.clone(), ());
-                mul_chip.assign(&mut layouter, a, b, cond.clone())?
+                mul_chip.assign(&mut layouter, a, b, cond)?
             }
             Opcode::Div => {
                 let div_chip = DivChip::<F>::construct(self.config.div_config.clone(), ());
-                div_chip.assign(&mut layouter, a, b, cond.clone())?
+                div_chip.assign(&mut layouter, a, b, cond)?
             }
             Opcode::Mod => {
                 let mod_chip = ModChip::<F>::construct(self.config.mod_config.clone(), ());
-                mod_chip.assign(&mut layouter, a, b, cond.clone())?
+                mod_chip.assign(&mut layouter, a, b, cond)?
             }
             Opcode::Eq => {
                 let eq_chip = EqChip::<F>::construct(self.config.eq_config.clone(), ());
-                eq_chip.assign(&mut layouter, a, b, cond.clone())?
+                eq_chip.assign(&mut layouter, a, b, cond)?
             }
             Opcode::Neq => {
                 let neq_chip = NeqChip::<F>::construct(self.config.neq_config.clone(), ());
-                neq_chip.assign(&mut layouter, a, b, cond.clone())?
+                neq_chip.assign(&mut layouter, a, b, cond)?
             }
             Opcode::And => {
                 let and_chip = AndChip::<F>::construct(self.config.and_config.clone(), ());
-                and_chip.assign(&mut layouter, a, b, cond.clone())?
+                and_chip.assign(&mut layouter, a, b, cond)?
             }
             Opcode::Or => {
                 let or_chip = OrChip::<F>::construct(self.config.or_config.clone(), ());
-                or_chip.assign(&mut layouter, a, b, cond.clone())?
+                or_chip.assign(&mut layouter, a, b, cond)?
             }
             Opcode::Lt => {
                 let lt_chip = LtChip::<F>::construct(self.config.lt_config.clone(), ());
-                lt_chip.assign(&mut layouter, a, b, cond.clone())?
+                lt_chip.assign(&mut layouter, a, b, cond)?
             }
             _ => unreachable!(),
         };

--- a/vm/src/chips/utilities.rs
+++ b/vm/src/chips/utilities.rs
@@ -205,7 +205,7 @@ impl<F: FieldExt, const NUM_OF_BYTES: usize> RangeCheckChip<F, NUM_OF_BYTES> {
                 let value =
                     self.config
                         .value_cell
-                        .assign(&mut region, 0, input_value.value().clone())?;
+                        .assign(&mut region, 0, input_value.value())?;
                 region
                     .constrain_equal(input_value.cell().ok_or(Error::Synthesis)?, value.cell())?;
                 self.config

--- a/vm/src/chips/utilities.rs
+++ b/vm/src/chips/utilities.rs
@@ -202,10 +202,10 @@ impl<F: FieldExt, const NUM_OF_BYTES: usize> RangeCheckChip<F, NUM_OF_BYTES> {
             |mut region: Region<'_, F>| {
                 self.config.s_range.enable(&mut region, 0)?;
                 self.config.cond_cell.assign(&mut region, 0, cond)?;
-                let value =
-                    self.config
-                        .value_cell
-                        .assign(&mut region, 0, input_value.value())?;
+                let value = self
+                    .config
+                    .value_cell
+                    .assign(&mut region, 0, input_value.value())?;
                 region
                     .constrain_equal(input_value.cell().ok_or(Error::Synthesis)?, value.cell())?;
                 self.config

--- a/vm/src/circuit.rs
+++ b/vm/src/circuit.rs
@@ -42,7 +42,7 @@ impl<'l> MoveCircuit<'l> {
     }
 
     pub fn loader(&self) -> &'l MoveLoader {
-        &self.loader
+        self.loader
     }
 
     pub fn state(&self) -> &StateStore {

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -52,10 +52,7 @@ impl<F: FieldExt> Frame<F> {
         condition: Option<F>,
     ) -> VmResult<ProgramBlock<F>> {
         let code = self.function.code();
-        let not_condition = match condition {
-            Some(v) => Some(F::one() - v),
-            None => None,
-        };
+        let not_condition = condition.map(|v| F::one() - v);
         let (_br_type, true_branch_start) = match &code[pc as usize] {
             Bytecode::BrTrue(offset) => (true, *offset),
             _ => {
@@ -168,8 +165,8 @@ impl<F: FieldExt> Frame<F> {
                                         layouter.namespace(|| {
                                             format!("merge locals in step#{}", interp.step)
                                         }),
-                                        &t_branch.block.locals(),
-                                        &f_branch.block.locals(),
+                                        t_branch.block.locals(),
+                                        f_branch.block.locals(),
                                         t_branch.block.condition(),
                                     )?;
                                     self.current_block = next_running;

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -1,16 +1,9 @@
 // Copyright (c) zkMove Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#![allow(clippy::clone_on_copy)]
 #![allow(clippy::from_over_into)]
-#![allow(clippy::len_without_is_empty)]
-#![allow(clippy::manual_map)]
-#![allow(clippy::needless_borrow)]
-#![allow(clippy::new_without_default)]
 #![allow(clippy::redundant_clone)]
-#![allow(clippy::redundant_closure)]
 #![allow(clippy::should_implement_trait)]
-#![allow(clippy::single_match)]
 
 pub mod chips;
 pub mod circuit;

--- a/vm/src/locals.rs
+++ b/vm/src/locals.rs
@@ -49,12 +49,13 @@ impl<F: FieldExt> Locals<F> {
         self.0.borrow().len()
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     pub fn get(&self, index: usize) -> Option<Value<F>> {
         let values = self.0.borrow();
-        match values.get(index) {
-            Some(v) => Some(v.clone()),
-            None => None,
-        }
+        values.get(index).cloned()
     }
 }
 

--- a/vm/src/program_block.rs
+++ b/vm/src/program_block.rs
@@ -405,7 +405,7 @@ impl<F: FieldExt> ProgramBlock<F> {
                             t.clone(),
                             f.clone(),
                             condition,
-                            )
+                        )
                         .map_err(|e| {
                             error!("merge locals failed: {:?}", e);
                             RuntimeError::from(e)

--- a/vm/src/program_block.rs
+++ b/vm/src/program_block.rs
@@ -221,7 +221,7 @@ impl<F: FieldExt> Block<F> {
                                 a,
                                 self.condition(),
                             )
-                            .map_err(|e| RuntimeError::from(e))?;
+                            .map_err(RuntimeError::from)?;
                         interp.stack.push(b)
                     }
                     Bytecode::Lt => {
@@ -397,24 +397,21 @@ impl<F: FieldExt> ProgramBlock<F> {
     ) -> VmResult<()> {
         debug_assert!(t_locals.len() == f_locals.len());
         for i in 0..t_locals.len() {
-            match (t_locals.get(i), f_locals.get(i)) {
-                (Some(t), Some(f)) => {
-                    if !t.equals(&f) {
-                        let local = evaluation_chip
-                            .conditional_select(
-                                layouter.namespace(|| format!("merge_locals {}", i)),
-                                t.clone(),
-                                f.clone(),
-                                condition,
+            if let (Some(t), Some(f)) = (t_locals.get(i), f_locals.get(i)) {
+                if !t.equals(&f) {
+                    let local = evaluation_chip
+                        .conditional_select(
+                            layouter.namespace(|| format!("merge_locals {}", i)),
+                            t.clone(),
+                            f.clone(),
+                            condition,
                             )
-                            .map_err(|e| {
-                                error!("merge locals failed: {:?}", e);
-                                RuntimeError::from(e)
-                            })?;
-                        self.locals().store(i, local)?;
-                    }
+                        .map_err(|e| {
+                            error!("merge locals failed: {:?}", e);
+                            RuntimeError::from(e)
+                        })?;
+                    self.locals().store(i, local)?;
                 }
-                _ => {}
             }
         }
         Ok(())

--- a/vm/src/runtime.rs
+++ b/vm/src/runtime.rs
@@ -29,6 +29,12 @@ pub struct Runtime<F: FieldExt> {
     _marker: PhantomData<F>,
 }
 
+impl<F: FieldExt> Default for Runtime<F> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<F: FieldExt> Runtime<F> {
     pub fn new() -> Self {
         Runtime {

--- a/vm/src/stack.rs
+++ b/vm/src/stack.rs
@@ -107,10 +107,7 @@ impl<F: FieldExt> CondStack<F> {
     }
 
     pub fn top(&self) -> Option<F> {
-        match self.0.last() {
-            Some(v) => Some(*v),
-            None => None,
-        }
+        self.0.last().copied()
     }
 }
 


### PR DESCRIPTION
Below lint entry is discarded from "vm/src/lib.rs".
=============
#![allow(clippy::clone_on_copy)]
#![allow(clippy::len_without_is_empty)]
#![allow(clippy::manual_map)]
#![allow(clippy::needless_borrow)]
#![allow(clippy::new_without_default)]
#![allow(clippy::redundant_closure)]
#![allow(clippy::single_match)]

Test result:
======== 
% cargo clippy --all-targets -- -D warnings
    Checking vm v0.1.0 (/Users/benliu/work/exercise/zkmove-lite/vm)
    Checking functional-tests v0.1.0 (/Users/benliu/work/exercise/zkmove-lite/functional-tests)
    Checking zkmove-cli v0.1.0 (/Users/benliu/work/exercise/zkmove-lite/cli)
    Finished dev [unoptimized + debuginfo] target(s) in 1.83s
% cargo build
   Compiling vm v0.1.0 (/Users/benliu/work/exercise/zkmove-lite/vm)
   Compiling functional-tests v0.1.0 (/Users/benliu/work/exercise/zkmove-lite/functional-tests)
   Compiling zkmove-cli v0.1.0 (/Users/benliu/work/exercise/zkmove-lite/cli)
    Finished dev [unoptimized + debuginfo] target(s) in 13.18s